### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#useful-things#
+# useful-things #
 _[Not to be confused with "needful things" (see King, Stephen)]_
 
 * __useful pack__: app store safe and general purpose
@@ -101,12 +101,12 @@ Deliberate touches.  See [my write up on InformIT](http://www.informit.com/artic
 ***View Dragging***
 From my Auto Layout book, adds constraint-based view dragging. This version is tweaked to remove constraints after moves because I needed to use it to demonstrate view dynamics. For use with the [Drag In View](http://www.informit.com/articles/article.aspx?p=2217000).
 
-##Books##
+## Books ##
 * [Latest Cookbook](https://github.com/erica/iOS-7-Cookbook)
 * [Auto Layout](https://github.com/erica/Auto-Layout-Demystified)
 * [Drawing/Quartz](https://github.com/erica/iOS-Drawing)
 
-##Various##
+## Various ##
 * [NSArray Utilities](https://github.com/erica/NSArray-Utilities)
 * [NSDate Utilities](https://github.com/erica/NSDate-Extensions)
 * [NSObject Utilities](https://github.com/erica/NSObject-Utility-Categories)

--- a/temporary kit/README.md
+++ b/temporary kit/README.md
@@ -1,3 +1,3 @@
-#Temporary Things#
+# Temporary Things #
 
 Items available for test drive and feedback. These are for books and projects that aren't yet public.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
